### PR TITLE
Lazily inject deps using service locater pattern + Ext function

### DIFF
--- a/app/src/main/java/com/example/heady/ShoppyApplication.kt
+++ b/app/src/main/java/com/example/heady/ShoppyApplication.kt
@@ -1,5 +1,6 @@
 package com.example.heady
 
+import com.example.heady.di.AppComponent
 import com.example.heady.di.DaggerAppComponent
 import dagger.android.AndroidInjector
 import dagger.android.DaggerApplication
@@ -17,6 +18,7 @@ import timber.log.Timber
 
 class ShoppyApplication : DaggerApplication(){
 
+    lateinit var component : AppComponent
     override fun onCreate() {
         super.onCreate()
         Timber.plant(Timber.DebugTree())
@@ -31,7 +33,8 @@ class ShoppyApplication : DaggerApplication(){
 
 
     override fun applicationInjector(): AndroidInjector<out DaggerApplication> {
-        return DaggerAppComponent.builder().application(this).build()
+        component = DaggerAppComponent.builder().application(this).build()
+        return component
     }
 
 }

--- a/app/src/main/java/com/example/heady/categories/childcategory/ChildCategoryActivity.kt
+++ b/app/src/main/java/com/example/heady/categories/childcategory/ChildCategoryActivity.kt
@@ -9,15 +9,18 @@ import com.example.heady.categories.BannerAdapter
 import com.example.heady.categories.BannerClickManager
 import com.example.heady.categories.subcategory.subCategoryIntent
 import com.example.heady.model.Category
+import com.example.heady.utils.inject
 import com.example.heady.utils.plusAssign
 import dagger.android.support.DaggerAppCompatActivity
-import kotlinx.android.synthetic.main.activity_child_categories.*
-import kotlinx.android.synthetic.main.toolbar_with_title.*
+import kotlinx.android.synthetic.main.activity_child_categories.api_error_text
+import kotlinx.android.synthetic.main.activity_child_categories.loader
+import kotlinx.android.synthetic.main.activity_child_categories.rv
+import kotlinx.android.synthetic.main.toolbar_with_title.page_title
+import kotlinx.android.synthetic.main.toolbar_with_title.toolbar
 import rx.android.schedulers.AndroidSchedulers
 import rx.schedulers.Schedulers
 import rx.subscriptions.CompositeSubscription
 import timber.log.Timber
-import javax.inject.Inject
 
 /**
  * Display list of Child Categories like
@@ -37,7 +40,14 @@ fun Context.childCategoryIntent(category_id : Int, category_name : String) : Int
 
 class ChildCategoryActivity : DaggerAppCompatActivity(),BannerClickManager{
 
-    @Inject lateinit var viewModel : ChildCategoryViewModel
+    /**
+     * Service locator pattern:
+     * Instead of the using member injection, we are trying to fetch
+     * the dependencies generated in DaggerAppComponent using provision method in AppComponent interface + Extension function
+     * This allows us to instantiate dependencies lazily using Ext function defined in DaggerUtil.kt
+     */
+    private val viewModel : ChildCategoryViewModel by inject { childCategoryViewModel() }
+
     private val compositeSubscription by lazy(LazyThreadSafetyMode.NONE) { CompositeSubscription() }
     private val adapter by lazy(LazyThreadSafetyMode.NONE) { BannerAdapter(this) }
 

--- a/app/src/main/java/com/example/heady/categories/subcategory/SubCategoryActivity.kt
+++ b/app/src/main/java/com/example/heady/categories/subcategory/SubCategoryActivity.kt
@@ -12,16 +12,18 @@ import com.example.heady.categories.childcategory.ChildCategoryViewModel
 import com.example.heady.categories.childcategory.ChildCategoryViewState
 import com.example.heady.model.Category
 import com.example.heady.products.productsListIntent
+import com.example.heady.utils.inject
 import com.example.heady.utils.plusAssign
-import com.example.heady.utils.toast
 import dagger.android.support.DaggerAppCompatActivity
-import kotlinx.android.synthetic.main.activity_sub_category.*
-import kotlinx.android.synthetic.main.toolbar_with_title.*
+import kotlinx.android.synthetic.main.activity_sub_category.api_error_text
+import kotlinx.android.synthetic.main.activity_sub_category.loader
+import kotlinx.android.synthetic.main.activity_sub_category.rv
+import kotlinx.android.synthetic.main.toolbar_with_title.page_title
+import kotlinx.android.synthetic.main.toolbar_with_title.toolbar
 import rx.android.schedulers.AndroidSchedulers
 import rx.schedulers.Schedulers
 import rx.subscriptions.CompositeSubscription
 import timber.log.Timber
-import javax.inject.Inject
 
 /**
  * Shows SubCategories of Child Categories like Formal Shoes and Casual shoes under Foot Wear
@@ -39,7 +41,13 @@ fun Context.subCategoryIntent(category_id : Int, category_name : String) : Inten
 }
 
 class SubCategoryActivity() : DaggerAppCompatActivity(),BannerClickManager{
-    @Inject lateinit var viewModel : ChildCategoryViewModel
+    /**
+     * Service locator pattern:
+     * Instead of the using member injection, we are trying to fetch
+     * the dependencies generated in DaggerAppComponent using provision method in AppComponent interface + Extension function
+     * This allows us to instantiate dependencies lazily using Ext function defined in DaggerUtil.kt
+     */
+    private val viewModel : ChildCategoryViewModel by inject { childCategoryViewModel() }
 
     private val compositeSubscription by lazy(LazyThreadSafetyMode.NONE) { CompositeSubscription() }
     private val adapter by lazy(LazyThreadSafetyMode.NONE) { BannerAdapter(this) }

--- a/app/src/main/java/com/example/heady/di/AppComponent.kt
+++ b/app/src/main/java/com/example/heady/di/AppComponent.kt
@@ -2,6 +2,8 @@ package com.example.heady.di
 
 import android.app.Application
 import com.example.heady.ShoppyApplication
+import com.example.heady.categories.childcategory.ChildCategoryViewModel
+import com.example.heady.categories.parentcategory.MainViewModel
 import dagger.BindsInstance
 import dagger.Component
 import dagger.android.AndroidInjector
@@ -17,6 +19,9 @@ import javax.inject.Singleton
         ActivityBindingModule::class,
         AndroidSupportInjectionModule::class))
 interface AppComponent : AndroidInjector<ShoppyApplication> {
+
+    fun mainViewModel() : MainViewModel
+    fun childCategoryViewModel() : ChildCategoryViewModel
 
     @Component.Builder
     interface Builder{

--- a/app/src/main/java/com/example/heady/utils/DaggerUtil.kt
+++ b/app/src/main/java/com/example/heady/utils/DaggerUtil.kt
@@ -1,0 +1,20 @@
+package com.example.heady.utils
+
+import android.content.Context
+import android.support.v4.app.Fragment
+import com.example.heady.ShoppyApplication
+import com.example.heady.di.AppComponent
+import kotlin.LazyThreadSafetyMode.NONE
+
+inline fun <reified T> Fragment.inject(
+    noinline initializer : AppComponent.() -> T) = lazy{
+  context?.let {
+    (it.applicationContext as ShoppyApplication).component.initializer()
+  } ?: throw IllegalStateException("Context must be set before accessing this property")
+}
+
+
+inline fun <reified T> Context.inject(
+    noinline initializer : AppComponent.() -> T) = lazy(NONE){
+  (applicationContext as ShoppyApplication).component.initializer()
+}


### PR DESCRIPTION
Trying to inject dependencies using the idea mentioned in this [article](https://medium.com/@sam.pengilly/using-dagger-in-android-the-idiomatic-kotlin-way-d5eca4c887bb )

Basically, we are using Extension function to lazily inject the deps provided from AppComponent interface's public provision methods instead of using Member injection.

Purpose of doing this is because when we use Member injection we are forced to define the dependency which we wish to inject using  `lateinit var` thereby not allowing us to use `vals` for those things.

Not sure if its good practice, but just wanted to try out how this works out.
This is more like using AppComponent interface as ServiceLocator in Fragment/Activity.
