### PR TITLE
Add Travis CI to the project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+language: android
+
+before_install:
+  - yes | sdkmanager "platforms;android-27"
+  - yes | sdkmanager "build-tools;27.0.3"
+
+android:
+  components:
+    - tools
+    - platform-tools
+    - build-tools-27.0.3
+    - android-27
+
+    # Additional components
+    - extra-google-google_play_services
+    - extra-google-m2repository
+    - extra-android-m2repository
+    - addon-google_apis-google-27
+
+  licenses:
+    - 'android-sdk-preview-license-.+'
+    - 'android-sdk-license-.+'
+
+jdk: oraclejdk8
+
+notifications:
+  email: false
+
+script:
+  - ./gradlew build check
+
+before_cache:
+    - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+cache:
+  directories:
+    - $HOME/.m2
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,7 @@ android {
         applicationId "com.example.heady"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
+        buildToolsVersion rootProject.ext.buildToolsVersion
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,9 @@ task clean(type: Delete) {
 ext {
     //Build
     minSdkVersion = 21
-    targetSdkVersion = 26
-    compileSdkVersion = 26
-    buildToolsVersion = "26.0.2"
+    targetSdkVersion = 27
+    compileSdkVersion = 27
+    buildToolsVersion = "27.0.3"
 
     //UI
     supportLibraryVersion = "27.0.2"

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,6 @@ ext {
     rxandroidVersion = "1.2.1"
 
     //Logging
-    timberVersion = "4.6.0"
+    timberVersion = "4.7.0"
     chuckVersion = "1.0.3"
 }


### PR DESCRIPTION
- Add Travis CI to the project
- Bump compileSdkVersion and buildToolsVersion while we are at it.
- Bump Timber version from `4.6.0` -> `4.7.0` to avoid lint issues